### PR TITLE
Do not include languages by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.1.2] - 2024-03-12
+
+### Added
+- Add functions to load and register languages
+
+### Changed
+- Update dependencies
+- Switch to using `core.js` for highlight (reduce size by not including languages)
+- Update README to reflect changes and instruct on registering languages
+
 ## [v0.1.1] - 2024-03-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,10 +29,55 @@ Markdown parser for [`@aegisjsproject/core`](https://github.com/AegisJSProject/c
 - [Contributing](./.github/CONTRIBUTING.md)
 <!-- - [Security Policy](./.github/SECURITY.md) -->
 
+## Adding language support
+
+In order to reduce bundle size, only plaintext is available/supported by default.
+However, you can easily add support for additional languages in a variety of ways:
+
+### Registering from Static Imports
+
+**Note**: All languages provided by `highlight.js` may be found at [`/es/languages/${lang}.min.js`](https://unpkg.com/browse/@highlightjs/cdn-assets/es/languages/).
+
+```js
+import { registerLanguage } from '@aegisjsproject/markdown';
+import javascript from 'highlight.js/lanuages/javascript.min.js';
+import xml from 'highlight.js/languages/xml.min.js';
+import css from 'highlight.js/languages/css.min.js';
+
+registerLanguage('javascript', javascript);
+registerLanguage('xml', xml);
+registerLanguage('css',css);
+
+// Or
+import { registerLanguages } from '@aegisjsproject/markdown';
+import javascript from 'highlight.js/lanuages/javascript.min.js';
+import xml from 'highlight.js/languages/xml.min.js';
+import css from 'highlight.js/languages/css.min.js';
+
+registerLanguages({ javascript, xml, css });
+```
+
+### Dynamically Loading and Registering using Dynamic Imports
+
+This uses `import()` for dynamic loading of language modules from `unpkg.com`.
+
+**Note**: These are case-sensitive and **MUST** be the correct filename (without extension).
+
+```js
+import { loadLanguages } from '@aegisjsproject/markdown';
+
+await loadLanguages('javascript', 'css', 'xml', 'typescript');
+```
+
 ## Example
 
 ```js
-import { md, createStyleSheet, getMarkdown } from '@aegisjsproject/markdown';
+import { md, createStyleSheet, getMarkdown, registerLanguages } from '@aegisjsproject/markdown';
+import javascript from 'highlight.js/languages/javascript.min.js';
+import css from 'highlight.js/languages/css.min.js';
+import xml from 'highlight.js/languages/xml.min.js';
+
+registerLanguages({ javascript, css, xml });
 
 document.head.append(
 	createStyleSheet('github', { media: '(prefers-color-scheme: light)' }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/markdown",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/markdown",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/markdown",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Markdown parser for `@aegisjsproject/core`",
   "keywords": [
     "aegis",

--- a/test/index.html
+++ b/test/index.html
@@ -6,14 +6,14 @@
 		<meta name="color-scheme" content="light dark" />
 		<meta http-equiv="Content-Security-Policy"
 			content="default-src 'none';
-			script-src 'self' https://unpkg.com/@shgysk8zer0/ 'sha384-b4AE0Ukz5l5K/3zmn4xPLR31Q8sKZmlmfN0L9x54tXdAQYREFfmaTdd/ks3Tz3tw';
+			script-src 'self' https://unpkg.com/@shgysk8zer0/ https://unpkg.com/@highlightjs/ 'sha384-4LGOteXsZnXUIRWdWoTgyYxE6BEOQ/T/AQrVJVpNxPCyWBRL6jyYvKABj6+6JePg';
 			style-src 'self' blob: data: https://unpkg.com/@highlightjs/;
 			img-src 'self' https://img.shields.io/ https://github.com/AegisJSProject/markdown/workflows/ https://github.com/AegisJSProject/markdown/actions/workflows/;
 			connect-src 'self';
 			trusted-types empty#html empty#script sanitizer-raw#html default;
 			require-trusted-types-for 'script';" />
 		<title>Aegis Markdown Test</title>
-		<script type="importmap" integrity="sha384-b4AE0Ukz5l5K/3zmn4xPLR31Q8sKZmlmfN0L9x54tXdAQYREFfmaTdd/ks3Tz3tw">
+		<script type="importmap" integrity="sha384-4LGOteXsZnXUIRWdWoTgyYxE6BEOQ/T/AQrVJVpNxPCyWBRL6jyYvKABj6+6JePg">
 			{
 				"imports": {
 					"@aegisjsproject/core": "../node_modules/@aegisjsproject/core/core.js",
@@ -22,8 +22,8 @@
 					"@aegisjsproject/styles/": "../node_modules/@aegisjsproject/styles/",
 					"@aegisjsproject/markdown": "../markdown.js",
 					"@aegisjsproject/markdown/": "../",
-					"highlight.js": "../node_modules/@highlightjs/cdn-assets/es/highlight.min.js",
-					"highlight.js/": "../node_modules/@highlightjs/cdn-assets/",
+					"highlight.js": "../node_modules/@highlightjs/cdn-assets/es/core.min.js",
+					"highlight.js/": "../node_modules/@highlightjs/cdn-assets/es/",
 					"marked": "../node_modules/marked/lib/marked.esm.js",
 					"marked-highlight": "../node_modules/marked-highlight/src/index.js",
 					"@shgysk8zer0/": "https://unpkg.com/@shgysk8zer0/"

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,9 @@
-import { md, createStyleSheet, getMarkdown } from '@aegisjsproject/markdown';
+import { md, createStyleSheet, getMarkdown, registerLanguages } from '@aegisjsproject/markdown';
+import javascript from 'highlight.js/languages/javascript.min.js';
+import css from 'highlight.js/languages/css.min.js';
+import xml from 'highlight.js/languages/xml.min.js';
+
+registerLanguages({ javascript, css, xml });
 
 document.head.append(
 	createStyleSheet('github', { media: '(prefers-color-scheme: light)' }),


### PR DESCRIPTION
This significantly reduces size.

- Update dependencies
- Switch to using `core.js` for highlight (reduce size by not including
languages)
- Update README to reflect changes and instruct on registering languages

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
